### PR TITLE
Add font file check

### DIFF
--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -44,6 +44,7 @@ Implementation Notes
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_framebuf.git"
 
+import os
 import struct
 
 # Framebuf format constants:
@@ -364,6 +365,9 @@ class BitmapFont:
             print("Could not find font file", font_name)
             raise
         self.font_width, self.font_height = struct.unpack('BB', self._font.read(2))
+        # simple font file validation check based on expected file size
+        if 2 + 256 * self.font_width != os.stat(font_name)[6]:
+            raise RuntimeError("Invalid font file: " + font_name)
 
     def deinit(self):
         """Close the font file as cleanup."""


### PR DESCRIPTION
**oled_test.py** (rst pin changed as needed)
```python
import board
import digitalio
import adafruit_ssd1306

rst = digitalio.DigitalInOut(board.D22)

disp = adafruit_ssd1306.SSD1306_I2C(128, 64, board.I2C(), reset=rst, addr=0x3d)

disp.fill(0)
disp.fill_rect(5, 20, 30, 10, 1)
disp.text('hello world', 0, 0, 1)
disp.show()

```
### CircuitPython
**BAD Font File**
```python
Adafruit CircuitPython 4.1.0 on 2019-08-03; Adafruit Metro M4 Express with samd51j19
>>> import oled_test
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "oled_test.py", line 11, in <module>
  File "/lib/adafruit_framebuf.py", line 313, in text
  File "/lib/adafruit_framebuf.py", line 370, in __init__
RuntimeError: Invalid font file: font5x8.bin
>>> 
```

**GOOD Font File**
```python
Adafruit CircuitPython 4.1.0 on 2019-08-03; Adafruit Metro M4 Express with samd51j19
>>> import oled_test
>>> 
```

### Blinka
**BAD Font File**
```console
pi@pizerow:~/oled_test $ python3 oled_test.py 
Traceback (most recent call last):
  File "oled_test.py", line 11, in <module>
    disp.text('hello world', 0, 0, 1)
  File "/home/pi/repos/Adafruit_CircuitPython_framebuf/adafruit_framebuf.py", line 313, in text
    self._font = BitmapFont()
  File "/home/pi/repos/Adafruit_CircuitPython_framebuf/adafruit_framebuf.py", line 370, in __init__
    raise RuntimeError("Invalid font file: " + font_name)
RuntimeError: Invalid font file: font5x8.bin
pi@pizerow:~/oled_test $
```

**GOOD Font File**
```console
pi@pizerow:~/oled_test $ python3 oled_test.py 
pi@pizerow:~/oled_test $ 
```