### PR TITLE
Add font_name to BitmapFont call for custom fonts 

### DIFF
--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -359,7 +359,7 @@ class FrameBuffer:
         for chunk in string.split("\n"):
             if not self._font or self._font.font_name != font_name:
                 # load the font!
-                self._font = BitmapFont()
+                self._font = BitmapFont(font_name)
             w = self._font.font_width
             for i, char in enumerate(chunk):
                 self._font.draw_char(


### PR DESCRIPTION
Hi all, 

I've been using this package as part of the `Adafruit_Python_SSD1306` package for few weeks now and I've been having issues making calls to the text drawing function using custom font paths (and consequently custom fonts as well). 

As it is right now, any call made to `adafruit_ssd1306.SSD1306_I2C.text()` with or without a `font_name=` parameter specified expects a file `font5x8.bin` in the current working directory of the calling script despite what may be specified, rendering the `font_name=` keyword param useless. 

After some digging it looks like the `BitmapFont` class is never instantiated with the `font_name` parameter, despite the `BitmapFont` class having a default parameter available to override. I have added the `font_name` parameter in the call to instantiate `BitmapFont` in this pull request, and it has fixed my build (allowing me to keep my font files out of the working directory of the active script).

Hopefully this pull request helps and this repo is still alive and well. Thanks