### PR TITLE
Add RGB565 format support

### DIFF
--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -134,8 +134,8 @@ class RGB565Format:
 
     @staticmethod
     def color_to_rgb565(color):
-        """Convert a color in either tuple or 24 bit integer form to RGB565, and return as two bytes
-        """
+        """Convert a color in either tuple or 24 bit integer form to RGB565,
+        and return as two bytes"""
         if isinstance(color, tuple):
             hibyte = (color[0] & 0xF8) | (color[1] >> 5)
             lobyte = ((color[1] << 5) & 0xE0) | (color[2] >> 3)

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -134,14 +134,15 @@ class RGB565Format:
 
     @staticmethod
     def color_to_rgb565(color):
-        """Convert a color in either tuple or 24 bit integer form to RGB565, and return as two bytes"""
+        """Convert a color in either tuple or 24 bit integer form to RGB565, and return as two bytes
+        """
         if isinstance(color, tuple):
-            hi = (color[0] & 0xF8) | (color[1] >> 5)
-            lo = ((color[1] << 5) & 0xE0) | (color[2] >> 3)
+            hibyte = (color[0] & 0xF8) | (color[1] >> 5)
+            lobyte = ((color[1] << 5) & 0xE0) | (color[2] >> 3)
         else:
-            hi = ((color >> 16) & 0xF8) | ((color >> 13) & 0x07)
-            lo = ((color >> 5) & 0xE0) | ((color >> 3) & 0x1F)
-        return bytes([lo, hi])
+            hibyte = ((color >> 16) & 0xF8) | ((color >> 13) & 0x07)
+            lobyte = ((color >> 5) & 0xE0) | ((color >> 3) & 0x1F)
+        return bytes([lobyte, hibyte])
 
     def set_pixel(self, framebuf, x, y, color):
         """Set a given pixel to a color."""
@@ -152,10 +153,10 @@ class RGB565Format:
     def get_pixel(framebuf, x, y):
         """Get the color of a given pixel"""
         index = (y * framebuf.stride + x) * 2
-        bl, bh = framebuf.buf[index : index + 2]
-        r = bh & 0xF8
-        g = ((bh & 0x07) << 5) | ((bl & 0xE0) >> 5)
-        b = (bl & 0x1F) << 3
+        lobyte, hibyte = framebuf.buf[index : index + 2]
+        r = hibyte & 0xF8
+        g = ((hibyte & 0x07) << 5) | ((lobyte & 0xE0) >> 5)
+        b = (lobyte & 0x1F) << 3
         return (r << 16) | (g << 8) | b
 
     def fill(self, framebuf, color):
@@ -167,6 +168,7 @@ class RGB565Format:
     def fill_rect(self, framebuf, x, y, width, height, color):
         """Draw a rectangle at the given location, size and color. The ``fill_rect`` method draws
         both the outline and interior."""
+        # pylint: disable=too-many-arguments
         rgb565_color = self.color_to_rgb565(color)
         for _y in range(2 * y, 2 * (y + height), 2):
             offset2 = _y * framebuf.stride

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -136,17 +136,11 @@ class RGB565Format:
     def color_to_rgb565(color):
         """Convert a color in either tuple or 24 bit integer form to RGB565, and return as two bytes"""
         if isinstance(color, tuple):
-            r = color[0] & 0xF8
-            gh = color[1] >> 5
-            gl = (color[1] << 5) & 0xE0
-            b = color[2] >> 3
+            hi = (color[0] & 0xF8) | (color[1] >> 5)
+            lo = ((color[1] << 5) & 0xE0) | (color[2] >> 3)
         else:
-            r = (color >> 16) & 0xF8
-            gh = (color >> 13) & 0x07
-            gl = (color >> 5) & 0xE0
-            b = (color >> 3) & 0x1F
-        hi = r + gh
-        lo = gl + b
+            hi = ((color >> 16) & 0xF8) | ((color >> 13) & 0x07)
+            lo = ((color >> 5) & 0xE0) | ((color >> 3) & 0x1F)
         return bytes([lo, hi])
 
     def set_pixel(self, framebuf, x, y, color):
@@ -174,9 +168,10 @@ class RGB565Format:
         """Draw a rectangle at the given location, size and color. The ``fill_rect`` method draws
         both the outline and interior."""
         rgb565_color = self.color_to_rgb565(color)
-        for _x in range(x, x + width):
-            for _y in range(y, y + height):
-                index = (_y * framebuf.stride + _x) * 2
+        for _y in range(2 * y, 2 * (y + height), 2):
+            offset2 = _y * framebuf.stride
+            for _x in range(2 * x, 2 * (x + width), 2):
+                index = offset2 + _x
                 framebuf.buf[index : index + 2] = rgb565_color
 
 

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -136,15 +136,15 @@ class RGB565Format:
     def color_to_rgb565(color):
         """Convert a color in either tuple or 24 bit integer form to RGB565, and return as two bytes"""
         if isinstance(color, tuple):
-            r = color[0] & 0xf8
+            r = color[0] & 0xF8
             gh = color[1] >> 5
-            gl = (color[1] << 5) & 0xe0
+            gl = (color[1] << 5) & 0xE0
             b = color[2] >> 3
         else:
-            r = (color >> 16) & 0xf8
+            r = (color >> 16) & 0xF8
             gh = (color >> 13) & 0x07
-            gl = (color >> 5) & 0xe0
-            b = (color >> 3) & 0x1f
+            gl = (color >> 5) & 0xE0
+            b = (color >> 3) & 0x1F
         hi = r + gh
         lo = gl + b
         return bytes([lo, hi])
@@ -152,23 +152,23 @@ class RGB565Format:
     def set_pixel(self, framebuf, x, y, color):
         """Set a given pixel to a color."""
         index = (y * framebuf.stride + x) * 2
-        framebuf.buf[index: index+2] = self.color_to_rgb565(color)
+        framebuf.buf[index : index + 2] = self.color_to_rgb565(color)
 
     @staticmethod
     def get_pixel(framebuf, x, y):
         """Get the color of a given pixel"""
         index = (y * framebuf.stride + x) * 2
-        bl, bh = framebuf.buf[index: index+2]
-        r = bh & 0xf8
-        g = ((bh & 0x07) << 5) | ((bl & 0xe0) >> 5)
-        b = (bl & 0x1f) << 3
+        bl, bh = framebuf.buf[index : index + 2]
+        r = bh & 0xF8
+        g = ((bh & 0x07) << 5) | ((bl & 0xE0) >> 5)
+        b = (bl & 0x1F) << 3
         return (r << 16) | (g << 8) | b
 
     def fill(self, framebuf, color):
         """completely fill/clear the buffer with a color"""
         rgb565_color = self.color_to_rgb565(color)
         for i in range(0, len(framebuf.buf), 2):
-            framebuf.buf[i: i + 2] = rgb565_color
+            framebuf.buf[i : i + 2] = rgb565_color
 
     def fill_rect(self, framebuf, x, y, width, height, color):
         """Draw a rectangle at the given location, size and color. The ``fill_rect`` method draws
@@ -177,7 +177,7 @@ class RGB565Format:
         for _x in range(x, x + width):
             for _y in range(y, y + height):
                 index = (_y * framebuf.stride + _x) * 2
-                framebuf.buf[index: index + 2] = rgb565_color
+                framebuf.buf[index : index + 2] = rgb565_color
 
 
 class RGB888Format:


### PR DESCRIPTION
Here's an RGB565 format.  Tested on a Beaglebone Black under python3, so it's possible there are CircuitPython incompatibilities. 