### PR TITLE
Add 2bit grayscale support

### DIFF
--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -46,10 +46,10 @@ class GS2HMSBFormat:
     @staticmethod
     def set_pixel(framebuf, x, y, color):
         """Set a given pixel to a color."""
-        index = (y * framebuf.stride + x) >> 2  # why 2?
+        index = (y * framebuf.stride + x) >> 2
         pixel = framebuf.buf[index]
 
-        shift = (x & 0b11) << 1  # why 1?
+        shift = (x & 0b11) << 1
         mask = 0b11 << shift
         color = (color & 0b11) << shift
 
@@ -58,10 +58,10 @@ class GS2HMSBFormat:
     @staticmethod
     def get_pixel(framebuf, x, y):
         """Get the color of a given pixel"""
-        index = (y * framebuf.stride + x) >> 2  # same as // 8? why?
+        index = (y * framebuf.stride + x) >> 2
         pixel = framebuf.buf[index]
 
-        shift = (x & 0b11) << 1  # why 1?
+        shift = (x & 0b11) << 1
         return (pixel >> shift) & 0b11
 
     @staticmethod

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -73,7 +73,7 @@ class GS2HMSBFormat:
         else:
             fill = 0x00
 
-        framebuf.buf = [ fill for i in range(len(framebuf.buf)) ]
+        framebuf.buf = [fill for i in range(len(framebuf.buf))]
 
     @staticmethod
     def rect(framebuf, x, y, width, height, color):

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -72,8 +72,8 @@ class GS2HMSBFormat:
             fill = (bits << 6) | (bits << 4) | (bits << 2) | (bits << 0)
         else:
             fill = 0x00
-        for i in range(len(framebuf.buf)):  # pylint: disable=consider-using-enumerate
-            framebuf.buf[i] = fill
+
+        framebuf.buf = [ fill for i in range(len(framebuf.buf)) ]
 
     @staticmethod
     def rect(framebuf, x, y, width, height, color):

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -37,19 +37,19 @@ RGB565 = 1  # 16-bit color displays
 GS4_HMSB = 2  # Unimplemented!
 MHMSB = 3  # Single bit displays like the Sharp Memory
 RGB888 = 4  # Neopixels and Dotstars
-GS2_HMSB = 5 # 2-bit color displays like the HT16K33 8x8 Matrix
+GS2_HMSB = 5  # 2-bit color displays like the HT16K33 8x8 Matrix
+
 
 class GS2HMSBFormat:
     """GS2HMSBFormat"""
 
-
     @staticmethod
     def set_pixel(framebuf, x, y, color):
         """Set a given pixel to a color."""
-        index = (y * framebuf.stride + x) >> 2 # why 2?
+        index = (y * framebuf.stride + x) >> 2  # why 2?
         pixel = framebuf.buf[index]
 
-        shift = (x & 0b11) << 1 # why 1?
+        shift = (x & 0b11) << 1  # why 1?
         mask = 0b11 << shift
         color = (color & 0b11) << shift
 
@@ -58,10 +58,10 @@ class GS2HMSBFormat:
     @staticmethod
     def get_pixel(framebuf, x, y):
         """Get the color of a given pixel"""
-        index = (y * framebuf.stride + x) >> 2 # same as // 8? why?
+        index = (y * framebuf.stride + x) >> 2  # same as // 8? why?
         pixel = framebuf.buf[index]
 
-        shift = (x & 0b11) << 1 # why 1?
+        shift = (x & 0b11) << 1  # why 1?
         return (pixel >> shift) & 0b11
 
     @staticmethod
@@ -80,7 +80,7 @@ class GS2HMSBFormat:
         # pylint: disable=too-many-arguments
         for _x in range(x, x + width):
             for _y in range(y, y + height):
-                if _x in [x, x+width] or _y in [y, y+height]:
+                if _x in [x, x + width] or _y in [y, y + height]:
                     GS2HMSBFormat.set_pixel(framebuf, _x, _y, color)
 
     @staticmethod
@@ -90,6 +90,7 @@ class GS2HMSBFormat:
         for _x in range(x, x + width):
             for _y in range(y, y + height):
                 GS2HMSBFormat.set_pixel(framebuf, _x, _y, color)
+
 
 class MHMSBFormat:
     """MHMSBFormat"""

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -16,6 +16,7 @@ Implementation Notes
 **Hardware:**
 
 * `Adafruit SSD1306 OLED displays <https://www.adafruit.com/?q=ssd1306>`_
+* `Adafruit HT16K33 Matrix displays <https://www.adafruit.com/?q=ht16k33>`_
 
 **Software and Dependencies:**
 
@@ -36,7 +37,57 @@ RGB565 = 1  # 16-bit color displays
 GS4_HMSB = 2  # Unimplemented!
 MHMSB = 3  # Single bit displays like the Sharp Memory
 RGB888 = 4  # Neopixels and Dotstars
+GS2_HMSB = 5 # 2-bit color displays like the HT16K33 8x8 Matrix
 
+class GS2HMSBFormat:
+    """GS2HMSBFormat"""
+
+
+    @staticmethod
+    def set_pixel(framebuf, x, y, color):
+        """Set a given pixel to a color."""
+        index = (y * framebuf.stride + x) >> 2 # why 2?
+        pixel = framebuf.buf[index]
+
+        shift = (x & 0b11) << 1 # why 1?
+        mask = 0b11 << shift
+        color = (color & 0b11) << shift
+
+        framebuf.buf[index] = color | (pixel & (~mask))
+
+    @staticmethod
+    def get_pixel(framebuf, x, y):
+        """Get the color of a given pixel"""
+        index = (y * framebuf.stride + x) >> 2 # same as // 8? why?
+        pixel = framebuf.buf[index]
+
+        shift = (x & 0b11) << 1 # why 1?
+        return (pixel >> shift) & 0b11
+
+    @staticmethod
+    def fill(framebuf, color):
+        """completely fill/clear the buffer with a color"""
+        if color:
+            fill = color & 0b11
+        else:
+            fill = 0x00
+        for i in range(len(framebuf.buf)):  # pylint: disable=consider-using-enumerate
+            framebuf.buf[i] = fill
+
+    @staticmethod
+    def rect(framebuf, x, y, width, height, color):
+        """Draw the outline of a rectangle at the given location, size and color."""
+        for xx in range(x, x + width):
+            for yy in range(y, y + height):
+                if xx in [x, x+width] or yy in [y, y+height]:
+                    GS2HMSBFormat.set_pixel(framebuf, xx, yy, color)
+
+    @staticmethod
+    def fill_rect(framebuf, x, y, width, height, color):
+        """Draw both the outline and interior of a rectangle at the given location, size and color."""
+        for xx in range(x, x + width):
+            for yy in range(y, y + height):
+                GS2HMSBFormat.set_pixel(framebuf, xx, yy, color)
 
 class MHMSBFormat:
     """MHMSBFormat"""
@@ -256,6 +307,8 @@ class FrameBuffer:
             self.format = RGB888Format()
         elif buf_format == RGB565:
             self.format = RGB565Format()
+        elif buf_format == GS2_HMSB:
+            self.format = GS2HMSBFormat()
         else:
             raise ValueError("invalid format")
         self._rotation = 0

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -68,7 +68,8 @@ class GS2HMSBFormat:
     def fill(framebuf, color):
         """completely fill/clear the buffer with a color"""
         if color:
-            fill = color & 0b11
+            bits = (color & 0b11)
+            fill = (bits << 6) | (bits << 4) | (bits << 2) | (bits << 0)
         else:
             fill = 0x00
         for i in range(len(framebuf.buf)):  # pylint: disable=consider-using-enumerate

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -68,7 +68,7 @@ class GS2HMSBFormat:
     def fill(framebuf, color):
         """completely fill/clear the buffer with a color"""
         if color:
-            bits = (color & 0b11)
+            bits = color & 0b11
             fill = (bits << 6) | (bits << 4) | (bits << 2) | (bits << 0)
         else:
             fill = 0x00
@@ -537,9 +537,7 @@ class FrameBuffer:
         imwidth, imheight = img.size
         if imwidth != width or imheight != height:
             raise ValueError(
-                "Image must be same dimensions as display ({0}x{1}).".format(
-                    width, height
-                )
+                f"Image must be same dimensions as display ({width}x{height})."
             )
         # Grab all the pixels from the image, faster than getpixel.
         pixels = img.load()

--- a/adafruit_framebuf.py
+++ b/adafruit_framebuf.py
@@ -77,17 +77,19 @@ class GS2HMSBFormat:
     @staticmethod
     def rect(framebuf, x, y, width, height, color):
         """Draw the outline of a rectangle at the given location, size and color."""
-        for xx in range(x, x + width):
-            for yy in range(y, y + height):
-                if xx in [x, x+width] or yy in [y, y+height]:
-                    GS2HMSBFormat.set_pixel(framebuf, xx, yy, color)
+        # pylint: disable=too-many-arguments
+        for _x in range(x, x + width):
+            for _y in range(y, y + height):
+                if _x in [x, x+width] or _y in [y, y+height]:
+                    GS2HMSBFormat.set_pixel(framebuf, _x, _y, color)
 
     @staticmethod
     def fill_rect(framebuf, x, y, width, height, color):
-        """Draw both the outline and interior of a rectangle at the given location, size and color."""
-        for xx in range(x, x + width):
-            for yy in range(y, y + height):
-                GS2HMSBFormat.set_pixel(framebuf, xx, yy, color)
+        """Draw the outline and interior of a rectangle at the given location, size and color."""
+        # pylint: disable=too-many-arguments
+        for _x in range(x, x + width):
+            for _y in range(y, y + height):
+                GS2HMSBFormat.set_pixel(framebuf, _x, _y, color)
 
 class MHMSBFormat:
     """MHMSBFormat"""


### PR DESCRIPTION
This lets people use framebuf for 2 color displays like the 8x8x2 matrix. It is a mostly mechanical port of the circuitpython GS2_HMSB code.

You can see how I use this code in https://github.com/jedahan/alarmclock , attached are terminal visualizations of `python3 blinkenlights.py` using some of this framebuf api:

<img width="490" alt="Screenshot 2023-02-04 at 2 11 36 PM" src="https://user-images.githubusercontent.com/32407/216785496-78c5c2bb-3a90-457b-94eb-bf3ee4c07791.png">

<img width="501" alt="Screenshot 2023-02-04 at 2 11 25 PM" src="https://user-images.githubusercontent.com/32407/216785497-150d2086-5eef-41a5-b529-5f9fa6f492ba.png">


https://user-images.githubusercontent.com/32407/216785487-a1d25784-6257-4a6b-b7d6-05d1a1f43dd0.mov

